### PR TITLE
Improve registration and my_team views

### DIFF
--- a/database2/urls.py
+++ b/database2/urls.py
@@ -29,5 +29,5 @@ urlpatterns = [
     path("entry/", views.entry, name="entry"),
     path("dashboard/", views.dashboard, name="dashboard"),
     path("register/", views.register, name="register"),
-    path("myteam/", views.myteam, name="myteam"),
+    path("myteam/", views.my_team, name="myteam"),
 ]


### PR DESCRIPTION
1. Authenticate as part of registration
2. Redirect to dashboard after successful registration
3. In registration, check for POST first so that we can render form on both GET requests and failed validation of POST form
4. Clean up my_team view by renaming to the Python style as well as using objects that already exist on the auth'd request.user